### PR TITLE
Add payrollGroupCode for organization-position examples

### DIFF
--- a/workforce/core/success/event-notification-organization-position.add-http-200-response.json
+++ b/workforce/core/success/event-notification-organization-position.add-http-200-response.json
@@ -35,6 +35,10 @@
                                     }
                                 }
                             ]
+                        },
+                        "payrollGroupCode": {
+                            "codeValue": "8",
+                            "shortName": "64-8"
                         }
                     }
                 }

--- a/workforce/core/success/event-notification-organization-position.change-http-200-response.json
+++ b/workforce/core/success/event-notification-organization-position.change-http-200-response.json
@@ -35,6 +35,10 @@
                                     }
                                 }
                             ]
+                        },
+                        "payrollGroupCode": {
+                            "codeValue": "8",
+                            "shortName": "65-8"
                         }
                     }
                 }

--- a/workforce/core/success/event-notification-organization-position.remove-http-200-response.json
+++ b/workforce/core/success/event-notification-organization-position.remove-http-200-response.json
@@ -32,6 +32,9 @@
                                     "wageLawNameCode": {}
                                 }
                             ]
+                        },
+                        "payrollGroupCode": {
+                            "shortName": ""
                         }
                     }
                 }

--- a/workforce/core/success/hr-organization-positions-http-200-response.json
+++ b/workforce/core/success/hr-organization-positions-http-200-response.json
@@ -23,6 +23,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -48,6 +52,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -73,6 +81,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -98,6 +110,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -123,6 +139,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "13",
+                "shortName": "64-13"
             }
         },
         {
@@ -148,6 +168,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -173,6 +197,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -198,6 +226,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -223,6 +255,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -248,6 +284,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -273,6 +313,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -298,6 +342,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -323,6 +371,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -348,6 +400,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -373,6 +429,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "12",
+                "shortName": "64-12"
             }
         },
         {
@@ -398,6 +458,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -423,6 +487,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -448,6 +516,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -473,6 +545,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -498,6 +574,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -523,6 +603,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "10",
+                "shortName": "64-10"
             }
         },
         {
@@ -548,6 +632,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -573,6 +661,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -598,6 +690,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -623,6 +719,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -648,6 +748,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -673,6 +777,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -698,6 +806,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -723,6 +835,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -748,6 +864,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -773,6 +893,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -798,6 +922,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -823,6 +951,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -848,6 +980,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -873,6 +1009,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -898,6 +1038,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -923,6 +1067,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -948,6 +1096,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -973,6 +1125,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -998,6 +1154,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -1023,6 +1183,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1048,6 +1212,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1073,6 +1241,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1098,6 +1270,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1123,6 +1299,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "65-8"
             }
         },
         {
@@ -1148,6 +1328,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -1173,6 +1357,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -1198,6 +1386,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1223,6 +1415,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1248,6 +1444,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1273,6 +1473,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1298,6 +1502,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1323,6 +1531,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -1348,6 +1560,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -1373,6 +1589,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1398,6 +1618,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -1423,6 +1647,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -1448,6 +1676,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -1473,6 +1705,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -1498,6 +1734,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -1523,6 +1763,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1548,6 +1792,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1573,6 +1821,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1598,6 +1850,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1623,6 +1879,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "10",
+                "shortName": "64-10"
             }
         },
         {
@@ -1648,6 +1908,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -1673,6 +1937,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1698,6 +1966,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1723,6 +1995,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "215-8"
             }
         },
         {
@@ -1748,6 +2024,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1773,6 +2053,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "3",
+                "shortName": "64-3"
             }
         },
         {
@@ -1798,6 +2082,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -1823,6 +2111,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -1848,6 +2140,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "12",
+                "shortName": "64-12"
             }
         },
         {
@@ -1873,6 +2169,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -1898,6 +2198,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -1923,6 +2227,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -1948,6 +2256,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "65-8"
             }
         },
         {
@@ -1973,6 +2285,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -1998,6 +2314,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2023,6 +2343,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2048,6 +2372,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -2073,6 +2401,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "12",
+                "shortName": "64-12"
             }
         },
         {
@@ -2098,6 +2430,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -2123,6 +2459,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -2148,6 +2488,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -2173,6 +2517,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2198,6 +2546,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2223,6 +2575,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2248,6 +2604,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2273,6 +2633,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2298,6 +2662,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2323,6 +2691,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -2348,6 +2720,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -2373,6 +2749,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -2398,6 +2778,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -2423,6 +2807,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "2",
+                "shortName": "65-2"
             }
         },
         {
@@ -2448,6 +2836,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2473,6 +2865,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2498,6 +2894,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "12",
+                "shortName": "64-12"
             }
         },
         {
@@ -2523,6 +2923,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -2548,6 +2952,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -2573,6 +2981,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -2598,6 +3010,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -2623,6 +3039,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2648,6 +3068,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -2673,6 +3097,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2698,6 +3126,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -2723,6 +3155,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2748,6 +3184,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2773,6 +3213,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2798,6 +3242,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "5",
+                "shortName": "64-5"
             }
         },
         {
@@ -2823,6 +3271,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2848,6 +3300,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2873,6 +3329,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2898,6 +3358,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2923,6 +3387,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -2948,6 +3416,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -2973,6 +3445,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -2998,6 +3474,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -3023,6 +3503,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -3048,6 +3532,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -3073,6 +3561,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "8",
+                "shortName": "64-8"
             }
         },
         {
@@ -3098,6 +3590,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -3123,6 +3619,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -3148,6 +3648,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -3173,6 +3677,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -3198,6 +3706,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -3223,6 +3735,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -3248,6 +3764,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -3273,6 +3793,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -3298,6 +3822,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -3323,6 +3851,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -3348,6 +3880,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -3373,6 +3909,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -3398,6 +3938,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -3423,6 +3967,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -3448,6 +3996,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -3473,6 +4025,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -3498,6 +4054,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "6",
+                "shortName": "64-6"
             }
         },
         {
@@ -3523,6 +4083,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -3548,6 +4112,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -3573,6 +4141,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "9",
+                "shortName": "64-9"
             }
         },
         {
@@ -3598,6 +4170,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "11",
+                "shortName": "64-11"
             }
         },
         {
@@ -3623,6 +4199,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         },
         {
@@ -3648,6 +4228,10 @@
                         }
                     }
                 ]
+            },
+            "payrollGroupCode": {
+                "codeValue": "7",
+                "shortName": "64-7"
             }
         }
     ]


### PR DESCRIPTION
Workforce's payrollScaleCode information goes inside Marketplace's payrollGroupCode